### PR TITLE
Fix heap docstring typo

### DIFF
--- a/leetcode/heap/main_test.py
+++ b/leetcode/heap/main_test.py
@@ -12,7 +12,7 @@ Reason:
   left(d, r) = (d+1, 2*r)
   right(d, r) = (d+1, 2*r + 1)
 
-Here we assume we are working with a mean heap
+Here we assume we are working with a min heap
 """
 
 import random


### PR DESCRIPTION
## Summary
- correct the docstring in `leetcode/heap/main_test.py`

## Testing
- `ruff check .`
- `pytest leetcode/heap/main_test.py -q`


------
https://chatgpt.com/codex/tasks/task_e_684493d1ac148331988ed16153b3e1b5