### PR TITLE
Add LCA BST helper and tests

### DIFF
--- a/leetcode/binary_tree_least_common_ancestor/BUILD
+++ b/leetcode/binary_tree_least_common_ancestor/BUILD
@@ -3,5 +3,8 @@ load("@rules_python//python:defs.bzl", "py_test")
 py_test(
     name = "main_test",
     srcs = ["main_test.py"],
-    deps = ["@pypi//pytest"],
+    deps = [
+        "@pypi//pytest",
+        "@pypi//pytest_timeout",
+    ],
 )

--- a/leetcode/binary_tree_least_common_ancestor/main_test.py
+++ b/leetcode/binary_tree_least_common_ancestor/main_test.py
@@ -13,6 +13,7 @@ import dataclasses
 import sys
 
 import pytest
+import pytest_timeout  # noqa: F401
 
 
 class TreeNode:
@@ -20,6 +21,30 @@ class TreeNode:
         self.val = x
         self.left = None
         self.right = None
+
+
+def build_bst() -> tuple[TreeNode, dict[int, TreeNode]]:
+    """Create a small binary search tree used in tests.
+
+    Returns the root node of the tree along with a mapping from node values
+    to the ``TreeNode`` instances so tests can easily access arbitrary nodes.
+    """
+
+    nodes = {val: TreeNode(val) for val in [6, 2, 0, 4, 3, 5, 8, 7, 9]}
+
+    nodes[6].left = nodes[2]
+    nodes[6].right = nodes[8]
+
+    nodes[2].left = nodes[0]
+    nodes[2].right = nodes[4]
+
+    nodes[4].left = nodes[3]
+    nodes[4].right = nodes[5]
+
+    nodes[8].left = nodes[7]
+    nodes[8].right = nodes[9]
+
+    return nodes[6], nodes
 
 
 # ==== [Solution 1]
@@ -69,24 +94,46 @@ def last_common_ancestor(root: TreeNode, p: TreeNode, q: TreeNode) -> TreeNode:
 
 
 def last_common_ancestor2(root: TreeNode, p: TreeNode, q: TreeNode) -> TreeNode:
-    def is_common(node: TreeNode | None) -> bool:
-        if node is None:
-            return False
-        return p.val <= node.val < q.val
+    if p.val > q.val:
+        p, q = q, p
 
     candidate = root
 
-    while True:
-        if is_common(candidate.left):
+    while candidate:
+        if q.val < candidate.val:
             candidate = candidate.left
-        elif is_common(candidate.right):
+        elif p.val > candidate.val:
             candidate = candidate.right
         else:
             return candidate
 
+    raise AssertionError("tree must contain p and q")
 
-def test_template() -> None:
-    pass
+
+@pytest.mark.timeout(3)
+@pytest.mark.parametrize(
+    "p_val,q_val,expected",
+    [
+        (2, 8, 6),
+        (2, 4, 2),
+        (3, 5, 4),
+        (0, 5, 2),
+        (7, 9, 8),
+        (4, 4, 4),
+    ],
+)
+def test_last_common_ancestor(p_val: int, q_val: int, expected: int) -> None:
+    root, nodes = build_bst()
+
+    p = nodes[p_val]
+    q = nodes[q_val]
+    if p.val > q.val:
+        p, q = q, p
+
+    expected_node = nodes[expected]
+
+    assert last_common_ancestor(root, p, q) is expected_node
+    assert last_common_ancestor2(root, p, q) is expected_node
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add helper to build a sample BST for tests
- implement parametrized tests for both LCA solutions
- fix `last_common_ancestor2` algorithm to correctly walk the BST
- document helper output
- add missing pytest-timeout plugin dependency

## Testing
- `ruff check leetcode/binary_tree_least_common_ancestor/main_test.py`
- `./bazel test ...` *(fails: could not download Bazel)*

------
https://chatgpt.com/codex/tasks/task_e_684493d956bc8331a034809f383a09ae